### PR TITLE
Fix AssertJ custom contract annotation for test checking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ repository.
 - No-op Mojo (`NullabilityMojo`) at `initialize` phase for plugin declaration and parameter documentation
 - Configurable checking modes: MAIN, TESTS, DISABLED
 - Support for `RequireExplicitNullMarking` check
-- Spring Contract and AssertJ ThrowingCallable custom contract annotations
+- Spring Contract and AssertJ `@Contract` custom contract annotations
 - Excludes test paths and generated sources by default
 - Preserves existing `maven-compiler-plugin` configuration
 - Integration tests via `maven-invoker-plugin`

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ All configuration parameters can be set either in the plugin `<configuration>` b
 When `checking` is set to `tests`, the plugin adds a separate configuration for `default-testCompile` with test-specific NullAway options:
 
 - `HandleTestAssertionLibraries=true`
-- AssertJ `ThrowingCallable` as a custom contract annotation
+- AssertJ `@Contract` as a custom contract annotation (requires AssertJ 3.27.4+)
 
 ### Existing compiler configuration
 

--- a/src/it/test-checking-error-detection/invoker.properties
+++ b/src/it/test-checking-error-detection/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean test-compile
+invoker.buildResult=failure

--- a/src/it/test-checking-error-detection/pom.xml
+++ b/src/it/test-checking-error-detection/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.example</groupId>
+	<artifactId>test-checking-error-detection</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<properties>
+		<maven.compiler.release>17</maven.compiler.release>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jspecify</groupId>
+			<artifactId>jspecify</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.14.0</version>
+			</plugin>
+			<plugin>
+				<groupId>am.ik.maven</groupId>
+				<artifactId>nullability-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<extensions>true</extensions>
+				<configuration>
+					<checking>tests</checking>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>configure</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/test-checking-error-detection/src/main/java/com/example/Greeter.java
+++ b/src/it/test-checking-error-detection/src/main/java/com/example/Greeter.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class Greeter {
+
+	private final String name;
+
+	public Greeter(String name) {
+		this.name = name;
+	}
+
+	public String greet() {
+		return "Hello, " + this.name + "!";
+	}
+
+}

--- a/src/it/test-checking-error-detection/src/test/java/com/example/GreeterTest.java
+++ b/src/it/test-checking-error-detection/src/test/java/com/example/GreeterTest.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class GreeterTest {
+
+	public String testGreeting() {
+		// NullAway error: returning null in @NullMarked context
+		return null;
+	}
+
+}

--- a/src/it/test-checking-error-detection/verify.groovy
+++ b/src/it/test-checking-error-detection/verify.groovy
@@ -1,0 +1,2 @@
+def buildLog = new File(basedir, "build.log").text
+assert buildLog.contains("NullAway") : "Build should fail due to NullAway error"

--- a/src/it/test-checking/invoker.properties
+++ b/src/it/test-checking/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean test-compile

--- a/src/it/test-checking/pom.xml
+++ b/src/it/test-checking/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.example</groupId>
+	<artifactId>test-checking</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<properties>
+		<maven.compiler.release>17</maven.compiler.release>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jspecify</groupId>
+			<artifactId>jspecify</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.27.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.12.1</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.14.0</version>
+			</plugin>
+			<plugin>
+				<groupId>am.ik.maven</groupId>
+				<artifactId>nullability-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<extensions>true</extensions>
+				<configuration>
+					<checking>tests</checking>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>configure</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/test-checking/src/main/java/com/example/Greeter.java
+++ b/src/it/test-checking/src/main/java/com/example/Greeter.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class Greeter {
+
+	private final String name;
+
+	public Greeter(String name) {
+		this.name = name;
+	}
+
+	public String greet() {
+		return "Hello, " + this.name + "!";
+	}
+
+}

--- a/src/it/test-checking/src/test/java/com/example/GreeterTest.java
+++ b/src/it/test-checking/src/test/java/com/example/GreeterTest.java
@@ -1,0 +1,41 @@
+package com.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+@NullMarked
+public class GreeterTest {
+
+	@Test
+	void assertThatIsNotNullNarrowsType() {
+		// HandleTestAssertionLibraries=true enables NullAway to understand
+		// that assertThat(...).isNotNull() acts as a null check
+		@Nullable String name = getNullableName();
+		assertThat(name).isNotNull();
+		// Without HandleTestAssertionLibraries, NullAway would flag this as
+		// passing @Nullable to @NonNull parameter
+		Greeter greeter = new Greeter(name);
+		assertThat(greeter.greet()).contains("World");
+	}
+
+	@Test
+	void failMethodContractNarrowsType() {
+		// AssertJ @Contract("_ -> fail") tells NullAway that fail() never returns,
+		// so code after fail() is unreachable and null narrowing applies
+		@Nullable String name = getNullableName();
+		if (name == null) {
+			fail("name must not be null");
+		}
+		Greeter greeter = new Greeter(name);
+		assertThat(greeter.greet()).contains("World");
+	}
+
+	private @Nullable String getNullableName() {
+		return "World";
+	}
+
+}

--- a/src/it/test-checking/verify.groovy
+++ b/src/it/test-checking/verify.groovy
@@ -1,0 +1,3 @@
+def buildLog = new File(basedir, "build.log").text
+assert buildLog.contains("checking=TESTS") : "Plugin should log checking=TESTS"
+assert buildLog.contains("BUILD SUCCESS") : "Build should succeed"

--- a/src/main/java/am/ik/maven/nullability/NullAwayArgsBuilder.java
+++ b/src/main/java/am/ik/maven/nullability/NullAwayArgsBuilder.java
@@ -26,7 +26,7 @@ public final class NullAwayArgsBuilder {
 
 	private static final String SPRING_CONTRACT = "org.springframework.lang.Contract";
 
-	private static final String ASSERTJ_CONTRACT = "org.assertj.core.api.ThrowableAssert.ThrowingCallable";
+	private static final String ASSERTJ_CONTRACT = "org.assertj.core.internal.annotation.Contract";
 
 	private NullAwayArgsBuilder() {
 	}

--- a/src/test/java/am/ik/maven/nullability/NullAwayArgsBuilderTest.java
+++ b/src/test/java/am/ik/maven/nullability/NullAwayArgsBuilderTest.java
@@ -68,7 +68,7 @@ class NullAwayArgsBuilderTest {
 		NullabilityConfiguration config = NullabilityConfiguration.defaults();
 		String result = NullAwayArgsBuilder.build(false, config);
 		assertThat(result).doesNotContain("HandleTestAssertionLibraries");
-		assertThat(result).doesNotContain("ThrowingCallable");
+		assertThat(result).doesNotContain("org.assertj.core.internal.annotation.Contract");
 	}
 
 	@Test
@@ -82,7 +82,7 @@ class NullAwayArgsBuilderTest {
 	void testsModeIncludesAssertJContract() {
 		NullabilityConfiguration config = NullabilityConfiguration.defaults();
 		String result = NullAwayArgsBuilder.build(true, config);
-		assertThat(result).contains("org.assertj.core.api.ThrowableAssert.ThrowingCallable");
+		assertThat(result).contains("org.assertj.core.internal.annotation.Contract");
 	}
 
 	@Test
@@ -90,15 +90,15 @@ class NullAwayArgsBuilderTest {
 		NullabilityConfiguration config = NullabilityConfiguration.defaults();
 		String result = NullAwayArgsBuilder.build(true, config);
 		assertThat(result).contains(
-				"-XepOpt:NullAway:CustomContractAnnotations=org.springframework.lang.Contract,org.assertj.core.api.ThrowableAssert.ThrowingCallable");
+				"-XepOpt:NullAway:CustomContractAnnotations=org.springframework.lang.Contract,org.assertj.core.internal.annotation.Contract");
 	}
 
 	@Test
 	void testsModeWithoutSpringContractIncludesOnlyAssertJ() {
 		NullabilityConfiguration config = NullabilityConfiguration.builder().springContractSupport(false).build();
 		String result = NullAwayArgsBuilder.build(true, config);
-		assertThat(result).contains(
-				"-XepOpt:NullAway:CustomContractAnnotations=org.assertj.core.api.ThrowableAssert.ThrowingCallable");
+		assertThat(result)
+			.contains("-XepOpt:NullAway:CustomContractAnnotations=org.assertj.core.internal.annotation.Contract");
 		assertThat(result).doesNotContain("org.springframework.lang.Contract");
 	}
 


### PR DESCRIPTION
## Summary

- Fix `CustomContractAnnotations` value from `ThrowingCallable` (functional interface, no effect) to `org.assertj.core.internal.annotation.Contract` (actual `@Contract` annotation added in AssertJ 3.27.4), matching the [spring-gradle-plugins/nullability-plugin](https://github.com/spring-gradle-plugins/nullability-plugin) implementation
- Add integration tests for `checking=tests` mode:
  - `test-checking`: verifies `HandleTestAssertionLibraries` (`assertThat().isNotNull()` null narrowing) and AssertJ `@Contract` (`fail()` method contract)
  - `test-checking-error-detection`: verifies NullAway detects null violations in test sources

## Test plan

- [x] All 43 unit tests pass
- [x] All 7 integration tests pass (including 2 new ones)
- [x] `./mvnw spring-javaformat:apply verify` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)