### PR TITLE
Test compatibility with Maven 4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,43 @@ on:
     - src/**
     - pom.xml
 jobs:
-  build:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up JDK 25
+      uses: actions/setup-java@v5
+      with:
+        java-version: '25'
+        distribution: 'liberica'
+        cache: maven
+    - name: Verify
+      run: ./mvnw -V --no-transfer-progress clean verify
+
+  test-maven4:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up JDK 25
+      uses: actions/setup-java@v5
+      with:
+        java-version: '25'
+        distribution: 'liberica'
+        cache: maven
+    - name: Download Maven 4
+      run: |
+        curl -fsSL -o /tmp/apache-maven-4.0.0-rc-5-bin.tar.gz https://dlcdn.apache.org/maven/maven-4/4.0.0-rc-5/binaries/apache-maven-4.0.0-rc-5-bin.tar.gz
+        tar xzf /tmp/apache-maven-4.0.0-rc-5-bin.tar.gz -C /tmp
+    - name: Verify with Maven 4
+      run: ./mvnw -V --no-transfer-progress clean verify -Dmaven4.home=/tmp/apache-maven-4.0.0-rc-5
+
+  deploy:
+    needs: [test, test-maven4]
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -25,7 +61,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Import Secrets
-      if: github.event_name != 'pull_request'
       id: secrets
       uses: hashicorp/vault-action@v3.4.0
       with:
@@ -39,7 +74,6 @@ jobs:
           kv/data/cicd/gpg secring | GPG_SECRING ;
           kv/data/cicd/gpg passphrase | GPG_PASSPHRASE ;
     - name: Set up JDK 25
-      if: github.event_name != 'pull_request'
       uses: actions/setup-java@v5
       with:
         java-version: '25'
@@ -47,17 +81,7 @@ jobs:
         cache: maven
         gpg-private-key: ${{ steps.secrets.outputs.GPG_SECRING }}
         gpg-passphrase: ${{ steps.secrets.outputs.GPG_PASSPHRASE }}
-    - name: Set up JDK 25 (PR)
-      if: github.event_name == 'pull_request'
-      uses: actions/setup-java@v5
-      with:
-        java-version: '25'
-        distribution: 'liberica'
-        cache: maven
-    - name: Unit Tests
-      run: ./mvnw -V --no-transfer-progress clean test verify
     - name: Generates Maven Settings
-      if: github.event_name != 'pull_request'
       uses: s4u/maven-settings-action@v4.0.0
       with:
         servers: |
@@ -67,7 +91,6 @@ jobs:
               "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_PASSWORD }}"
           }]
     - name: Deploy to Maven Central
-      if: github.event_name != 'pull_request'
       run: |
         set -e
         mvn -V \
@@ -80,6 +103,6 @@ jobs:
             -Dgpg.passphrase=${GPG_PASSPHRASE} \
             -DskipTests=true
     - name: Revoke token
-      if: always() && github.event_name != 'pull_request'
+      if: always()
       run: |
         curl -X POST -s -H "X-Vault-Token: ${VAULT_TOKEN}" ${{ secrets.VAULT_ADDR }}/v1/auth/token/revoke-self || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,9 @@ on:
     paths:
     - src/**
     - pom.xml
+env:
+  MAVEN4_VERSION: '4.0.0-rc-5'
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -46,10 +49,10 @@ jobs:
         cache: maven
     - name: Download Maven 4
       run: |
-        curl -fsSL -o /tmp/apache-maven-4.0.0-rc-5-bin.tar.gz https://dlcdn.apache.org/maven/maven-4/4.0.0-rc-5/binaries/apache-maven-4.0.0-rc-5-bin.tar.gz
-        tar xzf /tmp/apache-maven-4.0.0-rc-5-bin.tar.gz -C /tmp
+        curl -fsSL -o /tmp/apache-maven-${MAVEN4_VERSION}-bin.tar.gz https://dlcdn.apache.org/maven/maven-4/${MAVEN4_VERSION}/binaries/apache-maven-${MAVEN4_VERSION}-bin.tar.gz
+        tar xzf /tmp/apache-maven-${MAVEN4_VERSION}-bin.tar.gz -C /tmp
     - name: Verify with Maven 4
-      run: ./mvnw -V --no-transfer-progress clean verify -Dmaven4.home=/tmp/apache-maven-4.0.0-rc-5
+      run: ./mvnw -V --no-transfer-progress clean verify -Dmaven4.home=/tmp/apache-maven-${MAVEN4_VERSION}
 
   deploy:
     needs: [test, test-maven4]

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,37 @@
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>maven4-it</id>
+			<activation>
+				<property>
+					<name>maven4.home</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-invoker-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>maven4-integration-test</id>
+								<goals>
+									<goal>run</goal>
+								</goals>
+								<configuration>
+									<mavenHome>${maven4.home}</mavenHome>
+									<cloneProjectsTo>${project.build.directory}/it-maven4</cloneProjectsTo>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>


### PR DESCRIPTION
## Summary
- Add `maven4-it` profile in `pom.xml` that re-runs integration tests with Maven 4 when `-Dmaven4.home` is specified
- Refactor CI workflow from a single `build` job into `test`, `test-maven4`, and `deploy` jobs
- Maven 3 and Maven 4 tests run in parallel; deploy only executes after both succeed

Closes #6

## Test plan
- [x] All 9 ITs pass with Maven 3 (`./mvnw clean verify`)
- [x] All 9 ITs pass with Maven 4 RC-5 (`./mvnw clean verify -Dmaven4.home=/tmp/apache-maven-4.0.0-rc-5`)
- [x] YAML syntax validated
- [ ] CI pipeline runs successfully on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)