### PR TITLE
Replace springContractSupport with generic customContractAnnotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,15 @@ All configuration parameters can be set either in the plugin `<configuration>` b
 | `nullAwayVersion`            | `nullability.nullAwayVersion`            | (managed)                        | NullAway version                                                       |
 | `checking`                   | `nullability.checking`                   | `main`                           | Checking mode: `main`, `tests`, or `disabled`                          |
 | `requireExplicitNullMarking` | `nullability.requireExplicitNullMarking` | `true`                           | Enable `RequireExplicitNullMarking` check                              |
-| `springContractSupport`      | `nullability.springContractSupport`      | `true`                           | Add `org.springframework.lang.Contract` to custom contract annotations |
+| `customContractAnnotations`  | `nullability.customContractAnnotations`  |                                  | Comma-separated FQCNs of additional contract annotations               |
 | `jspecifyMode`               | `nullability.jspecifyMode`               | `true`                           | Enable NullAway's JSpecify mode (requires JDK 22+)                     |
 | `excludedPaths`              | `nullability.excludedPaths`              | `.*/target/generated-sources/.*` | Regex pattern for paths to exclude                                     |
 | `skip`                       | `nullability.skip`                       | `false`                          | Skip the plugin                                                        |
+
+Since NullAway 0.12.11, any annotation with the simple name `@Contract` is automatically recognized regardless of package (e.g. `org.springframework.lang.Contract`, `org.assertj.core.internal.annotation.Contract`). The `customContractAnnotations` parameter is only needed when:
+
+- Using a contract annotation whose simple name is not `Contract`
+- Using an older NullAway version (pre-0.12.11) that requires explicit registration
 
 ### `generate-package-info` goal configuration
 
@@ -170,8 +175,7 @@ The `checking` and `skip` parameters from the table above also apply to this goa
 
 When `checking` is set to `tests`, the plugin adds a separate configuration for `default-testCompile` with test-specific NullAway options:
 
-- `HandleTestAssertionLibraries=true`
-- AssertJ `@Contract` as a custom contract annotation (requires AssertJ 3.27.4+)
+- `HandleTestAssertionLibraries=true` -- enables `assertThat(x).isNotNull()` as null narrowing
 
 ### Existing compiler configuration
 

--- a/src/main/java/am/ik/maven/nullability/NullAwayArgsBuilder.java
+++ b/src/main/java/am/ik/maven/nullability/NullAwayArgsBuilder.java
@@ -17,16 +17,11 @@ package am.ik.maven.nullability;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.StringJoiner;
 
 /**
  * Builds the {@code -Xplugin:ErrorProne} argument string for main or test compilation.
  */
 public final class NullAwayArgsBuilder {
-
-	private static final String SPRING_CONTRACT = "org.springframework.lang.Contract";
-
-	private static final String ASSERTJ_CONTRACT = "org.assertj.core.internal.annotation.Contract";
 
 	private NullAwayArgsBuilder() {
 	}
@@ -64,9 +59,8 @@ public final class NullAwayArgsBuilder {
 			options.add("-XepOpt:NullAway:JSpecifyMode=true");
 		}
 
-		String customContracts = buildCustomContractAnnotations(forTests, config.springContractSupport());
-		if (!customContracts.isEmpty()) {
-			options.add("-XepOpt:NullAway:CustomContractAnnotations=" + customContracts);
+		if (config.customContractAnnotations() != null && !config.customContractAnnotations().isEmpty()) {
+			options.add("-XepOpt:NullAway:CustomContractAnnotations=" + config.customContractAnnotations());
 		}
 
 		if (forTests) {
@@ -99,17 +93,6 @@ public final class NullAwayArgsBuilder {
 			return "";
 		}
 		return "(" + String.join("|", patterns) + ")";
-	}
-
-	private static String buildCustomContractAnnotations(boolean forTests, boolean springContractSupport) {
-		StringJoiner joiner = new StringJoiner(",");
-		if (springContractSupport) {
-			joiner.add(SPRING_CONTRACT);
-		}
-		if (forTests) {
-			joiner.add(ASSERTJ_CONTRACT);
-		}
-		return joiner.toString();
 	}
 
 }

--- a/src/main/java/am/ik/maven/nullability/NullabilityConfiguration.java
+++ b/src/main/java/am/ik/maven/nullability/NullabilityConfiguration.java
@@ -29,13 +29,14 @@ import java.util.Properties;
  * {@link Checking#DISABLED})
  * @param requireExplicitNullMarking whether to enable the
  * {@code RequireExplicitNullMarking} check
- * @param springContractSupport whether to add {@code org.springframework.lang.Contract}
- * to custom contract annotations
+ * @param customContractAnnotations comma-separated FQCNs of additional contract
+ * annotations for NullAway
  * @param jspecifyMode whether to enable NullAway's JSpecify mode (requires JDK 22+)
  * @param excludedPaths regex pattern for paths to exclude from checking
  */
 public record NullabilityConfiguration(String errorProneVersion, String nullAwayVersion, Checking checking,
-		boolean requireExplicitNullMarking, boolean springContractSupport, boolean jspecifyMode, String excludedPaths) {
+		boolean requireExplicitNullMarking, String customContractAnnotations, boolean jspecifyMode,
+		String excludedPaths) {
 
 	private static final Properties DEFAULTS = loadDefaults();
 
@@ -95,7 +96,7 @@ public record NullabilityConfiguration(String errorProneVersion, String nullAway
 
 		private boolean requireExplicitNullMarking = true;
 
-		private boolean springContractSupport = true;
+		private String customContractAnnotations = "";
 
 		private boolean jspecifyMode = true;
 
@@ -124,8 +125,8 @@ public record NullabilityConfiguration(String errorProneVersion, String nullAway
 			return this;
 		}
 
-		public Builder springContractSupport(boolean springContractSupport) {
-			this.springContractSupport = springContractSupport;
+		public Builder customContractAnnotations(String customContractAnnotations) {
+			this.customContractAnnotations = customContractAnnotations;
 			return this;
 		}
 
@@ -141,7 +142,8 @@ public record NullabilityConfiguration(String errorProneVersion, String nullAway
 
 		public NullabilityConfiguration build() {
 			return new NullabilityConfiguration(this.errorProneVersion, this.nullAwayVersion, this.checking,
-					this.requireExplicitNullMarking, this.springContractSupport, this.jspecifyMode, this.excludedPaths);
+					this.requireExplicitNullMarking, this.customContractAnnotations, this.jspecifyMode,
+					this.excludedPaths);
 		}
 
 	}

--- a/src/main/java/am/ik/maven/nullability/NullabilityLifecycleParticipant.java
+++ b/src/main/java/am/ik/maven/nullability/NullabilityLifecycleParticipant.java
@@ -102,8 +102,8 @@ public class NullabilityLifecycleParticipant extends AbstractMavenLifecycleParti
 					.toUpperCase(Locale.ROOT)))
 			.requireExplicitNullMarking(getBooleanValue(config, "requireExplicitNullMarking",
 					resolveProperty(project, "nullability.requireExplicitNullMarking", "true")))
-			.springContractSupport(getBooleanValue(config, "springContractSupport",
-					resolveProperty(project, "nullability.springContractSupport", "true")))
+			.customContractAnnotations(getStringValue(config, "customContractAnnotations",
+					resolveProperty(project, "nullability.customContractAnnotations", "")))
 			.jspecifyMode(getBooleanValue(config, "jspecifyMode",
 					resolveProperty(project, "nullability.jspecifyMode", "true")))
 			.excludedPaths(getStringValue(config, "excludedPaths",

--- a/src/main/java/am/ik/maven/nullability/NullabilityMojo.java
+++ b/src/main/java/am/ik/maven/nullability/NullabilityMojo.java
@@ -53,11 +53,13 @@ public class NullabilityMojo extends AbstractMojo {
 	private boolean requireExplicitNullMarking;
 
 	/**
-	 * Whether to add {@code org.springframework.lang.Contract} to custom contract
-	 * annotations.
+	 * Comma-separated fully qualified class names of additional contract annotations for
+	 * NullAway. Since NullAway 0.12.11, annotations named {@code @Contract} are
+	 * auto-recognized regardless of package, so this is only needed for non-standard
+	 * annotation names.
 	 */
-	@Parameter(property = "nullability.springContractSupport", defaultValue = "true")
-	private boolean springContractSupport;
+	@Parameter(property = "nullability.customContractAnnotations", defaultValue = "")
+	private String customContractAnnotations;
 
 	/**
 	 * Whether to enable NullAway's JSpecify mode. When enabled, NullAway uses JSpecify

--- a/src/test/java/am/ik/maven/nullability/NullAwayArgsBuilderTest.java
+++ b/src/test/java/am/ik/maven/nullability/NullAwayArgsBuilderTest.java
@@ -50,17 +50,19 @@ class NullAwayArgsBuilderTest {
 	}
 
 	@Test
-	void mainModeWithSpringContractSupport() {
+	void customContractAnnotationsEmpty() {
 		NullabilityConfiguration config = NullabilityConfiguration.defaults();
 		String result = NullAwayArgsBuilder.build(false, config);
-		assertThat(result).contains("-XepOpt:NullAway:CustomContractAnnotations=org.springframework.lang.Contract");
+		assertThat(result).doesNotContain("CustomContractAnnotations");
 	}
 
 	@Test
-	void mainModeWithoutSpringContractSupport() {
-		NullabilityConfiguration config = NullabilityConfiguration.builder().springContractSupport(false).build();
+	void customContractAnnotationsSet() {
+		NullabilityConfiguration config = NullabilityConfiguration.builder()
+			.customContractAnnotations("com.example.MyContract")
+			.build();
 		String result = NullAwayArgsBuilder.build(false, config);
-		assertThat(result).doesNotContain("CustomContractAnnotations");
+		assertThat(result).contains("-XepOpt:NullAway:CustomContractAnnotations=com.example.MyContract");
 	}
 
 	@Test
@@ -68,7 +70,6 @@ class NullAwayArgsBuilderTest {
 		NullabilityConfiguration config = NullabilityConfiguration.defaults();
 		String result = NullAwayArgsBuilder.build(false, config);
 		assertThat(result).doesNotContain("HandleTestAssertionLibraries");
-		assertThat(result).doesNotContain("org.assertj.core.internal.annotation.Contract");
 	}
 
 	@Test
@@ -76,30 +77,6 @@ class NullAwayArgsBuilderTest {
 		NullabilityConfiguration config = NullabilityConfiguration.defaults();
 		String result = NullAwayArgsBuilder.build(true, config);
 		assertThat(result).contains("-XepOpt:NullAway:HandleTestAssertionLibraries=true");
-	}
-
-	@Test
-	void testsModeIncludesAssertJContract() {
-		NullabilityConfiguration config = NullabilityConfiguration.defaults();
-		String result = NullAwayArgsBuilder.build(true, config);
-		assertThat(result).contains("org.assertj.core.internal.annotation.Contract");
-	}
-
-	@Test
-	void testsModeWithSpringContractIncludesBothContracts() {
-		NullabilityConfiguration config = NullabilityConfiguration.defaults();
-		String result = NullAwayArgsBuilder.build(true, config);
-		assertThat(result).contains(
-				"-XepOpt:NullAway:CustomContractAnnotations=org.springframework.lang.Contract,org.assertj.core.internal.annotation.Contract");
-	}
-
-	@Test
-	void testsModeWithoutSpringContractIncludesOnlyAssertJ() {
-		NullabilityConfiguration config = NullabilityConfiguration.builder().springContractSupport(false).build();
-		String result = NullAwayArgsBuilder.build(true, config);
-		assertThat(result)
-			.contains("-XepOpt:NullAway:CustomContractAnnotations=org.assertj.core.internal.annotation.Contract");
-		assertThat(result).doesNotContain("org.springframework.lang.Contract");
 	}
 
 	@Test

--- a/src/test/java/am/ik/maven/nullability/NullabilityConfigurationTest.java
+++ b/src/test/java/am/ik/maven/nullability/NullabilityConfigurationTest.java
@@ -28,7 +28,7 @@ class NullabilityConfigurationTest {
 		assertThat(config.nullAwayVersion()).isEqualTo(NullabilityConfiguration.DEFAULT_NULLAWAY_VERSION);
 		assertThat(config.checking()).isEqualTo(Checking.MAIN);
 		assertThat(config.requireExplicitNullMarking()).isTrue();
-		assertThat(config.springContractSupport()).isTrue();
+		assertThat(config.customContractAnnotations()).isEmpty();
 		assertThat(config.jspecifyMode()).isTrue();
 		assertThat(config.excludedPaths()).isEqualTo(".*/target/generated-sources/.*");
 	}
@@ -40,7 +40,7 @@ class NullabilityConfigurationTest {
 			.nullAwayVersion("0.12.0")
 			.checking(Checking.TESTS)
 			.requireExplicitNullMarking(false)
-			.springContractSupport(false)
+			.customContractAnnotations("com.example.MyContract")
 			.jspecifyMode(false)
 			.excludedPaths(".*/generated/.*")
 			.build();
@@ -48,7 +48,7 @@ class NullabilityConfigurationTest {
 		assertThat(config.nullAwayVersion()).isEqualTo("0.12.0");
 		assertThat(config.checking()).isEqualTo(Checking.TESTS);
 		assertThat(config.requireExplicitNullMarking()).isFalse();
-		assertThat(config.springContractSupport()).isFalse();
+		assertThat(config.customContractAnnotations()).isEqualTo("com.example.MyContract");
 		assertThat(config.jspecifyMode()).isFalse();
 		assertThat(config.excludedPaths()).isEqualTo(".*/generated/.*");
 	}


### PR DESCRIPTION
## Summary

- Remove `springContractSupport` parameter (NullAway 0.12.11+ auto-recognizes any `@Contract` annotation regardless of package)
- Add generic `customContractAnnotations` parameter (default empty) as an escape hatch for non-standard annotation names
- Update README with new parameter documentation and NullAway auto-recognition note

Closes #15

## Test plan

- [x] All 49 unit tests pass
- [x] All 12 integration tests pass (`./mvnw verify`)
- [x] `test-checking` IT validates `@Contract` still works via auto-recognition

🤖 Generated with [Claude Code](https://claude.com/claude-code)