### PR TITLE
Rename NullabilityMojo to ConfigureMojo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ repository.
 
 - Automatic configuration of ErrorProne and NullAway for nullability checking
 - Lifecycle participant (`NullabilityLifecycleParticipant`) injects compiler configuration before build plan is computed
-- No-op Mojo (`NullabilityMojo`) at `initialize` phase for plugin declaration and parameter documentation
+- No-op Mojo (`ConfigureMojo`) at `initialize` phase for plugin declaration and parameter documentation
 - Configurable checking modes: MAIN, TESTS, DISABLED
 - Support for `RequireExplicitNullMarking` check
 - Spring Contract and AssertJ `@Contract` custom contract annotations
@@ -59,7 +59,7 @@ repository.
 ### After Task completion
 
 - Ensure all code is formatted using `./mvnw spring-javaformat:apply`
-- Run full test suite with `./mvnw test`
+- Run full test suite with `./mvnw verify`
 - For every task, notify that the task is complete and ready for review by the following command:
 
 ```

--- a/src/main/java/am/ik/maven/nullability/ConfigureMojo.java
+++ b/src/main/java/am/ik/maven/nullability/ConfigureMojo.java
@@ -26,7 +26,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * the lifecycle execution plan is computed.
  */
 @Mojo(name = "configure", defaultPhase = LifecyclePhase.INITIALIZE, threadSafe = true)
-public class NullabilityMojo extends AbstractMojo {
+public class ConfigureMojo extends AbstractMojo {
 
 	/**
 	 * The ErrorProne version to use.


### PR DESCRIPTION
## Summary
- Rename `NullabilityMojo` to `ConfigureMojo` to follow Maven convention of naming Mojo classes after their goal name (`configure` -> `ConfigureMojo`), consistent with `GeneratePackageInfoMojo`
- Update `CLAUDE.md` to use `mvn verify` instead of `mvn test` for the full test suite instruction

## Test plan
- [x] `./mvnw spring-javaformat:apply verify` passes (UT 49 + IT 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)