### PR TITLE
Add Javadoc comment to generated package-info.java

### DIFF
--- a/src/main/java/am/ik/maven/nullability/PackageInfoGenerator.java
+++ b/src/main/java/am/ik/maven/nullability/PackageInfoGenerator.java
@@ -90,8 +90,18 @@ public final class PackageInfoGenerator {
 			Path packageDir = outputDirectory.resolve(packageName.replace('.', '/'));
 			Files.createDirectories(packageDir);
 			Path packageInfoPath = packageDir.resolve(PACKAGE_INFO);
-			String content = "@NullMarked\npackage " + packageName
-					+ ";\n\nimport org.jspecify.annotations.NullMarked;\n";
+			// Include a Javadoc comment so that the generated package-info.java does not
+			// trigger "no comment" warnings when running the javadoc tool.
+			String content = """
+					/**
+					 * This package is null-marked: all types and their members are non-null by
+					 * default unless explicitly annotated as {@code @Nullable}.
+					 */
+					@NullMarked
+					package %s;
+
+					import org.jspecify.annotations.NullMarked;
+					""".formatted(packageName);
 			Files.writeString(packageInfoPath, content);
 			generated.add(packageName);
 		}

--- a/src/test/java/am/ik/maven/nullability/PackageInfoGeneratorTest.java
+++ b/src/test/java/am/ik/maven/nullability/PackageInfoGeneratorTest.java
@@ -57,6 +57,10 @@ class PackageInfoGeneratorTest {
 		assertThat(generatedFile).exists();
 		String content = Files.readString(generatedFile);
 		assertThat(content).isEqualTo("""
+				/**
+				 * This package is null-marked: all types and their members are non-null by
+				 * default unless explicitly annotated as {@code @Nullable}.
+				 */
 				@NullMarked
 				package com.example;
 


### PR DESCRIPTION
## Summary

Generated `package-info.java` files had no Javadoc comment, which caused `no comment` warnings when running the javadoc tool (e.g. `mvn compile javadoc:jar`) with doclint enabled (maven-javadoc-plugin enables doclint by default).

This change includes a Javadoc comment in the generated files to avoid these warnings.

Generated file now looks like:

```java
/**
 * This package is null-marked: all types and their members are non-null by
 * default unless explicitly annotated as {@code @Nullable}.
 */
@NullMarked
package com.example;

import org.jspecify.annotations.NullMarked;
```

## Test plan

- Updated `PackageInfoGeneratorTest` to assert the new content
- Full unit test suite passes (`./mvnw spring-javaformat:apply test`)
- Verified with `javadoc -Xdoclint:all`: the `package-info.java:2: warning: no comment` warning is gone after adding the comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)