### PR TITLE
Upgrade JSpecify from 1.0.0 to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You also need the JSpecify dependency:
 <dependency>
     <groupId>org.jspecify</groupId>
     <artifactId>jspecify</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </dependency>
 ```
 

--- a/src/it/basic-check/pom.xml
+++ b/src/it/basic-check/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/compiler-plugin-management/pom.xml
+++ b/src/it/compiler-plugin-management/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/errorprone-arg-element-name/pom.xml
+++ b/src/it/errorprone-arg-element-name/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/existing-compiler-config/pom.xml
+++ b/src/it/existing-compiler-config/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mapstruct</groupId>

--- a/src/it/existing-errorprone-config/pom.xml
+++ b/src/it/existing-errorprone-config/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/generate-package-info-in-source/pom.xml
+++ b/src/it/generate-package-info-in-source/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/src/it/generate-package-info-partial/pom.xml
+++ b/src/it/generate-package-info-partial/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/generate-package-info/pom.xml
+++ b/src/it/generate-package-info/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/no-compiler-plugin/pom.xml
+++ b/src/it/no-compiler-plugin/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/nullaway-error-detection/pom.xml
+++ b/src/it/nullaway-error-detection/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/nullaway-options/pom.xml
+++ b/src/it/nullaway-options/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/nullaway-warn-severity/pom.xml
+++ b/src/it/nullaway-warn-severity/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/test-checking-error-detection/pom.xml
+++ b/src/it/test-checking-error-detection/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/it/test-checking/pom.xml
+++ b/src/it/test-checking/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.jspecify</groupId>
 			<artifactId>jspecify</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>


### PR DESCRIPTION
Bumps the JSpecify version used across the repository from 1.0.0 to 1.0.1.

- 14 integration test projects under `src/it/*/pom.xml`
- README dependency example

`./mvnw verify` passes (15/15 integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)